### PR TITLE
Refactor: 디자인 가이드 페이지 정리 및 레이아웃 구조 개선

### DIFF
--- a/src/components/common/PlaylistCard.tsx
+++ b/src/components/common/PlaylistCard.tsx
@@ -1,4 +1,5 @@
 import PlaylistActions from "./PlaylistAction";
+import OverflowMenu from "./OverflowMenu";
 
 interface PlaylistCardProps {
   title: string;
@@ -15,6 +16,11 @@ const PlaylistCard = ({
   isPublic = true,
   isOwner,
 }: PlaylistCardProps) => {
+  const menuOptions = [
+    { label: "수정", action: () => alert("수정") },
+    { label: "삭제", action: () => alert("삭제") }
+  ];
+
   return (
     <>
       {/* 썸네일 */}
@@ -42,13 +48,7 @@ const PlaylistCard = ({
 
             {/* 수정, 삭제 메뉴 (본인의 플레이리스트일 때만 표시) */}
             {isOwner && (
-              <div role="button" className="mt-[2px]">
-                <img
-                  src="src/assets/icons/menu-dots-vertical.svg"
-                  alt="메뉴"
-                  className="w-[16px] h-[16px]"
-                />
-              </div>
+              <OverflowMenu options={menuOptions} />
             )}
           </div>
 

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -19,6 +19,7 @@ const Header = () => {
     "/mypage": "마이페이지",
     "/user/edit": "정보 수정",
     "/playlist/create": "플레이리스트 생성",
+    "/guide" : "컴포넌트 가이드"
   };
 
   let title = titleMap[location.pathname] || "페이지";

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -9,10 +9,14 @@ const Layout = () => {
   const hideAll = location.pathname === "/login";
   const hideNavOnly = ["/signup", "/user/edit", "/playlist/create"].includes(location.pathname);
 
+  // h-screen을 사용하면 콘텐츠가 길어질 때 배경이 흰색으로 깨지는 이슈 발생
+  // min-h-screen으로 수정하여 콘텐츠 길이에 따라 유동적으로 높이 조절되도록 함
+  // 네브바는 fixed이므로, 아래 콘텐츠가 가려지지 않도록 pb-[58px] 추가
+
   return (
-    <div className="flex flex-col h-screen">
+    <div className="flex flex-col min-h-screen">
       {!hideAll && <Header />}
-      <div className="flex-1 pt-[56px]">
+      <div className="flex-1 pt-[56px] pb-[58px]">
         <Outlet />
       </div>
 

--- a/src/pages/Guide.tsx
+++ b/src/pages/Guide.tsx
@@ -11,10 +11,10 @@ const ButtonGuide = () => {
       <div className="p-4 border border-gray-600 rounded-xl my-4">
         <div className="mb-6">
           <h4 className="font-semibold">기본 버튼</h4>
-          <p className="mb-2 text-sm font-medium">기본</p>
+          <h5 className="mb-2 text-sm font-medium">기본</h5>
           <Button variant="full">저장</Button>
           <br />
-          <p className="mb-2 text-sm font-medium">비활성화</p>
+          <h5 className="mb-2 text-sm font-medium">비활성화</h5>
           <Button disabled variant="full">
             저장
           </Button>
@@ -22,17 +22,17 @@ const ButtonGuide = () => {
         <h4 className="font-semibold">작은 버튼</h4>
         <div className="flex flex-row gap-[20px]">
           <div>
-            <p className="mb-2 text-sm font-medium">기본</p>
+            <h5 className="mb-2 text-sm font-medium">기본</h5>
             <Button variant="small">중복확인</Button>
           </div>
           <div>
-            <p className="mb-2 text-sm font-medium">비활성화</p>
+            <h5 className="mb-2 text-sm font-medium">비활성화</h5>
             <Button disabled variant="small">
               중복확인
             </Button>
           </div>
           <div>
-            <p className="mb-2 text-sm font-medium">닫기</p>
+            <h5 className="mb-2 text-sm font-medium">닫기</h5>
             <Button variant="secondary">닫기</Button>
           </div>
         </div>
@@ -49,20 +49,20 @@ const InputGuide = () => {
       <h3 className="ml-[10px] text-xl font-bold">Input</h3>
       <div className="p-4 border border-gray-600 rounded-xl my-4">
         <div className="mb-6">
-          <p className="mb-2 text-sm font-medium">기본</p>
+          <h5 className="mb-2 text-sm font-medium">기본</h5>
           <Input type="text" placeholder="이름을 입력하세요" />
         </div>
         <div className="mb-6">
-          <p className="mb-2 text-sm font-medium">비밀번호</p>
+          <h5 className="mb-2 text-sm font-medium">비밀번호</h5>
           <Input type="password" placeholder="비밀번호를 입력하세요" />
         </div>
         <div className="mb-6">
           {/* delete 버튼 옵션 */}
-          <p className="mb-2 text-sm font-medium">delete 옵션 추가</p>
+          <h5 className="mb-2 text-sm font-medium">delete 옵션 추가</h5>
           <Input type="email" showDelete placeholder="이메일을 입력하세요" />
         </div>
         <div className="mb-6">
-          <p className="mb-2 text-sm font-medium">실시간 입력 미리보기</p>
+          <h5 className="mb-2 text-sm font-medium">실시간 입력 미리보기</h5>
           <Input
             type="text"
             placeholder="텍스트를 입력하세요"
@@ -76,12 +76,12 @@ const InputGuide = () => {
         </div>
         <div className="mb-6">
           {/* textarea 소개글 */}
-          <p className="mb-2 text-sm font-medium">textarea</p>
+          <h5 className="mb-2 text-sm font-medium">textarea</h5>
           <Input type="textarea" placeholder="소개글을 입력하세요" />
         </div>
         <div className="mb-6">
           {/* round */}
-          <p className="mb-2 text-sm font-medium">둥근 input</p>
+          <h5 className="mb-2 text-sm font-medium">둥근 input</h5>
           <Input type="round" placeholder="검색어를 입력하세요" />
         </div>
       </div>
@@ -100,10 +100,10 @@ const OverflowMenuGuide = () => {
       <h3 className="ml-[10px] text-xl font-bold">OverflowMenu</h3>
       <div className="p-4 border border-gray-600 rounded-xl my-4 flex flex-row gap-[10px]">
           {/* basic */}
-          <p className="text-sm font-medium">기본 메뉴</p>
+          <h5 className="text-sm font-medium">기본 메뉴</h5>
           <OverflowMenu options={menuOptions} />
           {/* iconSize */}
-          <p className="ml-[10px] text-sm font-medium">24px 사이즈</p>
+          <h5 className="ml-[10px] text-sm font-medium">24px 사이즈</h5>
           <OverflowMenu options={menuOptions} iconSize={24} />
       </div>
     </>
@@ -115,20 +115,20 @@ const PlaylistCardGuide = () => {
     <>
       <h3 className="ml-[10px] text-xl font-bold">PlaylistCard</h3>
       <div className="p-4 border border-gray-600 rounded-xl my-4">
-        <p className="mb-2 text-sm font-medium">홈 & 구독</p>
+        <h5 className="mb-2 text-sm font-medium">홈 & 구독</h5>
         <PlaylistCard
           title="[Ghibli OST Playlist] 감성 충만 지브리 OST 연주곡 모음집"
           thumbnailUrl="https://i.pinimg.com/736x/60/0c/b6/600cb65bd5f67e70a8fac0909e4c1ee6.jpg"
           userImage="https://i.pinimg.com/736x/17/c1/d9/17c1d903910937ecfd18943ee06279c2.jpg"
           isOwner={false}
         />
-        <p className="mb-2 text-sm font-medium">마이페이지 - 공개</p>
+        <h5 className="mb-2 text-sm font-medium">마이페이지 - 공개</h5>
         <PlaylistCard
           title="[Ghibli OST Playlist] 감성 충만 지브리 OST 연주곡 모음집"
           thumbnailUrl="https://i.pinimg.com/736x/60/0c/b6/600cb65bd5f67e70a8fac0909e4c1ee6.jpg"
           isOwner={true}
         />
-        <p className="mb-2 text-sm font-medium">마이페이지 - 비공개</p>
+        <h5 className="mb-2 text-sm font-medium">마이페이지 - 비공개</h5>
         <PlaylistCard
           title="[Ghibli OST Playlist] 감성 충만 지브리 OST 연주곡 모음집"
           thumbnailUrl="https://i.pinimg.com/736x/60/0c/b6/600cb65bd5f67e70a8fac0909e4c1ee6.jpg"

--- a/src/pages/Guide.tsx
+++ b/src/pages/Guide.tsx
@@ -2,25 +2,42 @@ import { useState } from "react";
 import { Button } from "../components/common/Button";
 import { Input } from "../components/common/Input";
 import OverflowMenu from "../components/common/OverflowMenu";
+import PlaylistCard from "../components/common/PlaylistCard";
 
 const ButtonGuide = () => {
   return (
-    <div>
-      <Button variant="full">저장</Button>
-      <br />
-      <Button disabled variant="full">
-        저장
-      </Button>
-      <br />
-      <Button variant="small">중복확인</Button>
-      <br />
-      <Button disabled variant="small">
-        중복확인
-      </Button>
-      <br />
-      <Button variant="secondary">닫기</Button>
-      <br />
-    </div>
+    <>
+      <h3 className="ml-[10px] text-xl font-bold">Button</h3>
+      <div className="p-4 border border-gray-600 rounded-xl my-4">
+        <div className="mb-6">
+          <h4 className="font-semibold">기본 버튼</h4>
+          <p className="mb-2 text-sm font-medium">기본</p>
+          <Button variant="full">저장</Button>
+          <br />
+          <p className="mb-2 text-sm font-medium">비활성화</p>
+          <Button disabled variant="full">
+            저장
+          </Button>
+        </div>
+        <h4 className="font-semibold">작은 버튼</h4>
+        <div className="flex flex-row gap-[20px]">
+          <div>
+            <p className="mb-2 text-sm font-medium">기본</p>
+            <Button variant="small">중복확인</Button>
+          </div>
+          <div>
+            <p className="mb-2 text-sm font-medium">비활성화</p>
+            <Button disabled variant="small">
+              중복확인
+            </Button>
+          </div>
+          <div>
+            <p className="mb-2 text-sm font-medium">닫기</p>
+            <Button variant="secondary">닫기</Button>
+          </div>
+        </div>
+      </div>
+    </>
   );
 };
 
@@ -28,26 +45,47 @@ const InputGuide = () => {
   const [inputValue, setInputValue] = useState("");
 
   return (
-    <div>
-      <Input type="text" placeholder="이름을 입력하세요" />
-      <Input type="password" placeholder="비밀번호를 입력하세요" />
-      {/* delete 버튼 옵션 */}
-      <Input type="email" showDelete placeholder="이메일을 입력하세요" />
-      <Input
-        type="text"
-        placeholder="텍스트를 입력하세요"
-        value={inputValue}
-        defaultValue="defaultValue"
-        onChange={(e) => setInputValue(e.target.value)}
-        showDelete
-      />
-      {/* inputValue 확인 */}
-      <p>{inputValue}</p>
-      {/* textarea 소개글 */}
-      <Input type="textarea" placeholder="소개글을 입력하세요" />
-      {/* round */}
-      <Input type="round" placeholder="검색어를 입력하세요" />
-    </div>
+    <>
+      <h3 className="ml-[10px] text-xl font-bold">Input</h3>
+      <div className="p-4 border border-gray-600 rounded-xl my-4">
+        <div className="mb-6">
+          <p className="mb-2 text-sm font-medium">기본</p>
+          <Input type="text" placeholder="이름을 입력하세요" />
+        </div>
+        <div className="mb-6">
+          <p className="mb-2 text-sm font-medium">비밀번호</p>
+          <Input type="password" placeholder="비밀번호를 입력하세요" />
+        </div>
+        <div className="mb-6">
+          {/* delete 버튼 옵션 */}
+          <p className="mb-2 text-sm font-medium">delete 옵션 추가</p>
+          <Input type="email" showDelete placeholder="이메일을 입력하세요" />
+        </div>
+        <div className="mb-6">
+          <p className="mb-2 text-sm font-medium">실시간 입력 미리보기</p>
+          <Input
+            type="text"
+            placeholder="텍스트를 입력하세요"
+            value={inputValue}
+            defaultValue="defaultValue"
+            onChange={(e) => setInputValue(e.target.value)}
+            showDelete
+          />
+          {/* inputValue 확인 */}
+          <p>{inputValue}</p>
+        </div>
+        <div className="mb-6">
+          {/* textarea 소개글 */}
+          <p className="mb-2 text-sm font-medium">textarea</p>
+          <Input type="textarea" placeholder="소개글을 입력하세요" />
+        </div>
+        <div className="mb-6">
+          {/* round */}
+          <p className="mb-2 text-sm font-medium">둥근 input</p>
+          <Input type="round" placeholder="검색어를 입력하세요" />
+        </div>
+      </div>
+    </>
   );
 };
 
@@ -59,16 +97,49 @@ const OverflowMenuGuide = () => {
 
   return (
     <>
-      {/* basic */}
-      <OverflowMenu options={menuOptions} />
-
-      {/* iconSize */}
-      <OverflowMenu options={menuOptions} iconSize={24} />
+      <h3 className="ml-[10px] text-xl font-bold">OverflowMenu</h3>
+      <div className="p-4 border border-gray-600 rounded-xl my-4 flex flex-row gap-[10px]">
+          {/* basic */}
+          <p className="text-sm font-medium">기본 메뉴</p>
+          <OverflowMenu options={menuOptions} />
+          {/* iconSize */}
+          <p className="ml-[10px] text-sm font-medium">24px 사이즈</p>
+          <OverflowMenu options={menuOptions} iconSize={24} />
+      </div>
     </>
   )
 }
 
+const PlaylistCardGuide = () => {
+  return (
+    <>
+      <h3 className="ml-[10px] text-xl font-bold">PlaylistCard</h3>
+      <div className="p-4 border border-gray-600 rounded-xl my-4">
+        <p className="mb-2 text-sm font-medium">홈 & 구독</p>
+        <PlaylistCard
+          title="[Ghibli OST Playlist] 감성 충만 지브리 OST 연주곡 모음집"
+          thumbnailUrl="https://i.pinimg.com/736x/60/0c/b6/600cb65bd5f67e70a8fac0909e4c1ee6.jpg"
+          userImage="https://i.pinimg.com/736x/17/c1/d9/17c1d903910937ecfd18943ee06279c2.jpg"
+          isOwner={false}
+        />
+        <p className="mb-2 text-sm font-medium">마이페이지 - 공개</p>
+        <PlaylistCard
+          title="[Ghibli OST Playlist] 감성 충만 지브리 OST 연주곡 모음집"
+          thumbnailUrl="https://i.pinimg.com/736x/60/0c/b6/600cb65bd5f67e70a8fac0909e4c1ee6.jpg"
+          isOwner={true}
+        />
+        <p className="mb-2 text-sm font-medium">마이페이지 - 비공개</p>
+        <PlaylistCard
+          title="[Ghibli OST Playlist] 감성 충만 지브리 OST 연주곡 모음집"
+          thumbnailUrl="https://i.pinimg.com/736x/60/0c/b6/600cb65bd5f67e70a8fac0909e4c1ee6.jpg"
+          isPublic={false}
+          isOwner={true}
+        />
 
+      </div>
+    </>
+  )
+}
 
 const Guide = () => {
   return (
@@ -76,6 +147,7 @@ const Guide = () => {
       <ButtonGuide />
       <InputGuide />
       <OverflowMenuGuide />
+      <PlaylistCardGuide />
     </>
   );
 };


### PR DESCRIPTION
## ✨ Related Issues
- 이슈 넘버 #

## 📝 Task Details

- Layout에서 콘텐츠가 길어질 때 배경이 흰색으로 노출되는 이슈를 해결했습니다.
▶️ `h-screen` → `min-h-screen` 으로 수정하여 콘텐츠 길이에 따라 유동적으로 높이가 조절되도록 했습니다.
- `Navbar`가 `fixed` 속성을 가지므로, 아래 콘텐츠가 가려지지 않도록 `pb-[58px]` 패딩을 추가했습니다.
- `Guide` 페이지에 공통 컴포넌트(Button, Input, PlaylistCard 등)의 사용 예시를 정리했습니다. 
- PlaylistCard에 overflowMenu를 적용했습니다. (action은 추후 수정 필요합니다.)

## 📂 References

![image](https://github.com/user-attachments/assets/f9bdf40b-baf4-4d2f-86e6-e224be1d499e)

