### PR TITLE
Style: 비공개 아이콘 추가 시 제목 정렬 스타일 수정

### DIFF
--- a/src/components/common/PlaylistCard.tsx
+++ b/src/components/common/PlaylistCard.tsx
@@ -45,15 +45,17 @@ const PlaylistCard = ({
         <div className="flex-1">
           {/* 플레이리스트 제목 */}
           <div className="flex items-start justify-between">
-            {/* 비공개 아이콘 */}
-            {!isPublic && (
-              <img
-                src="/src/assets/icons/lock.svg"
-                className="mr-[4px] mt-[2px] inline h-[16px] w-[16px]"
-              />
-            )}
-            {/* 제목 */}
-            <h3 className="line-clamp-2 text-body2 leading-[1.5] text-font-primary">{title}</h3>
+            <div className="flex flex-row gap-1">
+              {/* 비공개 아이콘 */}
+              {!isPublic && (
+                <img
+                  src="/src/assets/icons/lock.svg"
+                  className="mr-[4px] mt-[2px] inline h-[16px] w-[16px]"
+                />
+              )}
+              {/* 제목 */}
+              <h3 className="line-clamp-2 text-body2 leading-[1.5] text-font-primary">{title}</h3>
+            </div>
 
             {/* 수정, 삭제 메뉴 (본인의 플레이리스트일 때만 표시) */}
             {isOwner && (


### PR DESCRIPTION
## 📝 Task Details

- PlaylistCard 컴포넌트에서 비공개 아이콘이 표시될 때 제목이 가운데 정렬되는 이슈를 수정했습니다.
- 제목 정렬 스타일을 수정하여 비공개 아이콘 유무와 관계없이 일관된 정렬 유지했습니다.

## 📂 References

![playlistCard](https://github.com/user-attachments/assets/619eb2a6-6d6c-41e4-a425-962c5a8943e4)