### PR TITLE
Design: 댓글 스타일 수정

### DIFF
--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -10,10 +10,14 @@ interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   htmlFor?: string;
   value?: string;
+  inputClassName?: string;
 }
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, onChange, value = "", htmlFor, showDelete, label, ...props }, ref) => {
+  (
+    { className, type, onChange, value = "", htmlFor, showDelete, label, inputClassName, ...props },
+    ref,
+  ) => {
     const [showPassword, setShowPassword] = React.useState(false);
     const [inputValue, setInputValue] = React.useState(value);
 
@@ -42,6 +46,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       "flex w-full rounded bg-background-input px-3 py-[15px] !text-sub text-font-primary placeholder:text-font-placeholder focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
       "border-[1px] border-transparent focus:border-font-placeholder",
       (type === "password" || (showDelete && hasValue)) && "pr-10",
+      inputClassName,
     );
     const sharedProps = {
       onChange: handleChange,

--- a/src/components/playlistDetail/Comments.tsx
+++ b/src/components/playlistDetail/Comments.tsx
@@ -77,7 +77,7 @@ const Comments = () => {
       {isCommentsLoading ? (
         <p className="text-sub">Loading...</p>
       ) : isCommentsError ? (
-        <p className="text-sub text-red-500">댓글을 불러오는 데 실패했어요.</p>
+        <p className="text-red-500 text-sub">댓글을 불러오는 데 실패했어요.</p>
       ) : (
         <>
           <span>댓글 {comments.length}</span>
@@ -98,16 +98,21 @@ const Comments = () => {
             )}
           </form>
           {isPostError && (
-            <p className="text-sub text-red-500">댓글 등록에 실패했어요. 다시 시도해 주세요.</p>
+            <p className="text-red-500 text-sub">댓글 등록에 실패했어요. 다시 시도해 주세요.</p>
           )}
-          <ul className="flex flex-col gap-[13px] pb-10">
+          <ul className="flex flex-col gap-2">
             {comments.map((item) => (
-              <li key={item.id} className="relative flex flex-col">
-                <div className="flex gap-[10px]">
-                  <img src={item?.user?.profile_image} className="mt-[5px] h-6 w-6 rounded-full" />
-                  <p className="text-sub2 text-font-second">{item?.user?.nickname}</p>
+              <li key={item.id} className="flex gap-[10px]">
+                <img
+                  src={item?.user?.profile_image}
+                  className="mt-[5px] h-6 w-6 shrink-0 rounded-full"
+                />
+                <div className="flex flex-col">
+                  <p className="whitespace-nowrap text-sub2 text-font-second">
+                    {item?.user?.nickname}
+                  </p>
+                  <p className="text-body2">{item.content}</p>
                 </div>
-                <p className="absolute left-[34px] top-[18px] text-body2">{item.content}</p>
               </li>
             ))}
           </ul>

--- a/src/components/playlistDetail/Comments.tsx
+++ b/src/components/playlistDetail/Comments.tsx
@@ -100,14 +100,14 @@ const Comments = () => {
           {isPostError && (
             <p className="text-sub text-red-500">댓글 등록에 실패했어요. 다시 시도해 주세요.</p>
           )}
-          <ul className="flex flex-col gap-2">
+          <ul className="flex flex-col gap-[13px] pb-10">
             {comments.map((item) => (
-              <li key={item.id} className="flex items-center gap-[10px]">
-                <img src={item?.user?.profile_image} className="h-6 w-6 rounded-full" />
-                <div>
+              <li key={item.id} className="relative flex flex-col">
+                <div className="flex gap-[10px]">
+                  <img src={item?.user?.profile_image} className="mt-[5px] h-6 w-6 rounded-full" />
                   <p className="text-sub2 text-font-second">{item?.user?.nickname}</p>
-                  <p className="text-body2">{item.content}</p>
                 </div>
+                <p className="absolute left-[34px] top-[18px] text-body2">{item.content}</p>
               </li>
             ))}
           </ul>

--- a/src/components/playlistDetail/Comments.tsx
+++ b/src/components/playlistDetail/Comments.tsx
@@ -77,7 +77,7 @@ const Comments = () => {
       {isCommentsLoading ? (
         <p className="text-sub">Loading...</p>
       ) : isCommentsError ? (
-        <p className="text-red-500 text-sub">댓글을 불러오는 데 실패했어요.</p>
+        <p className="text-sub text-red-500">댓글을 불러오는 데 실패했어요.</p>
       ) : (
         <>
           <span>댓글 {comments.length}</span>
@@ -86,6 +86,7 @@ const Comments = () => {
               placeholder="댓글을 입력해 주세요"
               type="round"
               className="flex-grow"
+              inputClassName="pr-10"
               value={content}
               onChange={(e) => setContent(e.target.value)}
               disabled={isPosting}
@@ -97,12 +98,12 @@ const Comments = () => {
             )}
           </form>
           {isPostError && (
-            <p className="text-red-500 text-sub">댓글 등록에 실패했어요. 다시 시도해 주세요.</p>
+            <p className="text-sub text-red-500">댓글 등록에 실패했어요. 다시 시도해 주세요.</p>
           )}
           <ul className="flex flex-col gap-2">
             {comments.map((item) => (
               <li key={item.id} className="flex items-center gap-[10px]">
-                <img src={item?.user?.profile_image} className="w-6 h-6 rounded-full" />
+                <img src={item?.user?.profile_image} className="h-6 w-6 rounded-full" />
                 <div>
                   <p className="text-sub2 text-font-second">{item?.user?.nickname}</p>
                   <p className="text-body2">{item.content}</p>


### PR DESCRIPTION
## ✨ Related Issues
- 이슈 넘버 #66
- 이슈 넘버  #67

## 📝 Task Details

- input 내 text가 길어지면 오른쪽 등록 버튼 뒤로 text가 겹치는 현상이 있었습니다. Input 내 padding 값을 추가해야 하는데, Input Element 자체에 className이 안먹혀서 새로운 props `inputClassName`을 추가하는 식으로 등록 버튼이랑 겹치지 않도록 수정했습니다. 더 좋은 방식이 있다면 코멘트 남겨주세요..!
- 이전에는 댓글이 길어질 경우 프로필 이미지와 닉네임 + 내용이 가운데 정렬이 됐었는데, 프로필 이미지와 닉네임이 상단에 위치하도록 스타일 수정했습니다.

## 📂 References
![image](https://github.com/user-attachments/assets/a7c73394-cbaf-402d-a192-2aebd8573767)

## 💖 Review Requirements

- 리뷰 요구사항을 적어주세요!
