### PR TITLE
Fix: playlistCard 썸네일 비율 수정

### DIFF
--- a/src/components/common/PlaylistCard.tsx
+++ b/src/components/common/PlaylistCard.tsx
@@ -41,8 +41,14 @@ const PlaylistCard = ({
 
   return (
     <div className="cursor-pointer" onClick={handleCardClick}>
-      {/* 썸네일 */}
-      <img src={thumbnailUrl} alt="Playlist Thumbnail" className="w-full object-cover" />
+      {/* 썸네일 영역: 16:9 비율 */}
+      <div className="relative aspect-video w-full">
+        <img
+          src={thumbnailUrl}
+          alt="Playlist Thumbnail"
+          className="absolute inset-0 h-full w-full object-cover"
+        />
+      </div>
 
       {/* 정보 영역 */}
       <div className="flex flex-row px-[16px] py-[12px]">

--- a/src/components/playlistDetail/Comments.tsx
+++ b/src/components/playlistDetail/Comments.tsx
@@ -6,7 +6,7 @@ import { Input } from "../common/Input";
 import { Comment } from "../../types/comment";
 import axiosInstance from "../../services/axios/axiosInstance";
 import AddIcon from "../../assets/icons/fill-add.svg?react";
-import { useUserStore } from "../../store/useUserStore";
+import useUserStore from "../../store/useUserStore";
 import CommentSkeleton from "./CommentSkeleton";
 
 interface NewCommentPayload {


### PR DESCRIPTION
## ✨ Related Issues
- 이슈 넘버 #60 

## 📝 Task Details

- 공통 컴포넌트인 PlaylistCard의 썸네일 비율을 16:9로 수정했습니다.
- Zustand 스토어 import 오류 수정했습니다.

## 📂 References

![image](https://github.com/user-attachments/assets/68a5e2c1-c70d-43c6-b631-c985a5f8db72)
