### PR TITLE
Feat: 플레이리스트 상세페이지 추가 기능 구현

### DIFF
--- a/src/components/playlistDetail/Player.tsx
+++ b/src/components/playlistDetail/Player.tsx
@@ -3,11 +3,13 @@ import { PlaylistDetailData } from "../../types/playlist";
 import { Video } from "../../types/video";
 import PlaylistActions from "../common/PlaylistAction";
 import { formatDate } from "../../utils/formatData";
+import { useNavigate } from "react-router-dom";
 
 const MAX_DESCRIPTION_PREVIEW_LENGTH = 60;
 
 const Player = ({ playlist, video }: { playlist: PlaylistDetailData; video: Video }) => {
   const [isExpanded, setIsExpanded] = useState(false);
+  const navigate = useNavigate();
 
   const isClamped = playlist.description.length > MAX_DESCRIPTION_PREVIEW_LENGTH;
   const visibleText = isExpanded
@@ -52,6 +54,13 @@ const Player = ({ playlist, video }: { playlist: PlaylistDetailData; video: Vide
   const embedUrl = getEmbedUrl(video.url);
   const creator = playlist.user;
 
+  // 유저 정보 클릭 시 마이페이지로 이동
+  const handleCreatorClick = () => {
+    if (creator?.id) {
+      navigate(`/mypage/${creator.id}`);
+    }
+  };
+
   return (
     <>
       {/* 영상 영역 */}
@@ -69,7 +78,7 @@ const Player = ({ playlist, video }: { playlist: PlaylistDetailData; video: Vide
       <section className="space-y-4 px-4 pb-6 pt-3">
         {/* 유저 정보 */}
         <div className="flex items-center justify-between">
-          <div className="flex gap-2.5">
+          <div className="flex gap-2.5" onClick={handleCreatorClick}>
             <img src={creator?.profile_image} className="h-6 w-6 rounded-full" />
             <p>{creator?.nickname}</p>
           </div>


### PR DESCRIPTION
## ✨ Related Issues
- 이슈 넘버 #69 
- 이슈 넘버 #31 

## 📝 Task Details

- 유저 프로필 클릭 시 해당 유저의 마이페이지로 이동하는 기능 구현
- 플레이리스트 상세 페이지 헤더에 플레이리스트 제목 표시

## 📂 References

![image](https://github.com/user-attachments/assets/54c32720-1118-40a9-b1c8-241066c751be)

## 💖 Review Requirements

- 마이페이지 머지 후 테스트가 필요합니다.
