### PR TITLE
Fix: 내가 만든 플레이리스트인지 확인하는 로직 수정

### DIFF
--- a/src/components/common/PlaylistCard.tsx
+++ b/src/components/common/PlaylistCard.tsx
@@ -36,7 +36,7 @@ const PlaylistCard = ({
   ];
 
   const handleCardClick = () => {
-    navigate(`/playlist/${id}`, { state: { isOwner } });
+    navigate(`/playlist/${id}`);
   };
 
   return (

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -1,6 +1,5 @@
-import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
-
 import { useRef, useState, useEffect, RefObject } from "react";
+import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 
 import supabase from "@/services/supabase/supabaseClient";
 import axiosInstance from "@/services/axios/axiosInstance";
@@ -14,6 +13,8 @@ import Search from "@/assets/icons/search.svg?react";
 import OverflowMenu from "@/components/common/OverflowMenu";
 import SearchBar from "@/components/common/SearchBar";
 
+import { usePlaylistDetail } from "@/hooks/usePlaylistDetail";
+
 type HeaderProps = {
   onSearch?: (query: string) => void;
 };
@@ -25,12 +26,21 @@ const Header = ({ onSearch }: HeaderProps) => {
   const [playlistTitle, setPlaylistTitle] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
+  const [isOwner, setIsOwner] = useState(false);
+
   const searchInputRef: RefObject<HTMLInputElement | null> = useRef<HTMLInputElement>(null);
   const hiddenPaths = ["/login"];
   const { id: playlistId } = useParams();
+  const user = useUserStore((state) => state.user);
 
-  const { state } = location;
-  const isOwner = state?.isOwner;
+  const playlist = usePlaylistDetail(playlistId);
+
+  useEffect(() => {
+    if (!user) return;
+
+    if (playlist.data?.creator_id === user.id) setIsOwner(true);
+    else setIsOwner(false);
+  }, [location, playlist.data?.creator_id, user]);
 
   // 페이지 이동 시 검색 상태 초기화
   useEffect(() => {

--- a/src/pages/PlaylistCreate.tsx
+++ b/src/pages/PlaylistCreate.tsx
@@ -169,7 +169,7 @@ const PlaylistCreate = () => {
       setVideoList([]);
       setIsPublic(false);
 
-      navigate(`/playlist/${id}`, { state: { isOwner: true } });
+      navigate(`/playlist/${newPlaylistId}`);
     } catch (error) {
       console.error("생성 중 오류:", error);
     }
@@ -209,7 +209,7 @@ const PlaylistCreate = () => {
       setVideoList([]);
       setIsPublic(false);
 
-      navigate(`/playlist/${id}`, { state: { isOwner: true } });
+      navigate(`/playlist/${id}`);
     } catch (error) {
       console.error("수정 중 오류:", error);
     }


### PR DESCRIPTION
## ✨ Related Issues
- 이슈 넘버 #98

## 📝 Task Details

- `navigate(path, { state })`로 넘기는 `state는` 휘발성이라서, 새로고침하거나 직접 URL 입력해서 들어가면 사라져버린다고 합니다. 따라서 `usePlaylistDetail` 훅을 통해 playlist 정보를 가져와 creator_id와 현재 로그인된 유저의 id와 비교하는 로직으로 수정하였습니다.

## 📂 References

- 스크린샷이나 레퍼런스를 넣어주세요!

## 💖 Review Requirements

- 리뷰 요구사항을 적어주세요!
