### PR TITLE
Feat: playlistAction 컴포넌트에 구독/좋아요 상태 업데이트 구현

### DIFF
--- a/src/components/common/PlaylistAction.tsx
+++ b/src/components/common/PlaylistAction.tsx
@@ -1,28 +1,165 @@
-import { useState } from "react";
-import BookmarkIcon from "../../assets/icons/bookmark.svg?react";
-import HeartIcon from "../../assets/icons/heart.svg?react";
-import CommentIcon from "../../assets/icons/comment.svg?react";
+import { useEffect, useState } from "react";
+import useUserStore from "@/store/useUserStore";
+import axiosInstance from "@/services/axios/axiosInstance";
 
-// interface PlaylistActionsProps {
-//   playlistId: string; // 실제 API 연동 시 사용할 예정
-// }
+import BookmarkIcon from "@/assets/icons/bookmark.svg?react";
+import HeartIcon from "@/assets/icons/heart.svg?react";
+import CommentIcon from "@/assets/icons/comment.svg?react";
 
-const PlaylistActions = () => {
-  // 기본 값으로 더미 데이터 사용 (API 연결 전까지)
+interface PlaylistActionsProps {
+  playlistId: string;
+}
+
+const PlaylistActions = ({ playlistId }: PlaylistActionsProps) => {
+  const currentUser = useUserStore((state) => state.user);
+  const userId = currentUser?.id;
+
+  // 상태 관리
   const [isLiked, setIsLiked] = useState(false);
   const [isSubscribed, setIsSubscribed] = useState(false);
   const [likes, setLikes] = useState(0);
   const [subscriptions, setSubscriptions] = useState(0);
-  const [comments] = useState(0); // 댓글 수는 단순 표시용
+  // const [comments, setComments] = useState(0);
 
-  const handleLike = () => {
-    setIsLiked((prev) => !prev);
-    setLikes((prev) => (isLiked ? prev - 1 : prev + 1));
+  // 유저와 플레이리스트에 대한 기존 액션 정보 불러오기
+  useEffect(() => {
+    if (!userId) return;
+
+    const fetchActions = async () => {
+      try {
+        // 1. action 테이블에서 유저의 기존 상태 불러오기
+        const { data: actionData } = await axiosInstance.get(`/action`, {
+          params: {
+            playlist_id: `eq.${playlistId}`,
+            user_id: `eq.${userId}`,
+            select: "*",
+          },
+        });
+
+        if (actionData && actionData.length > 0) {
+          const action = actionData[0];
+          setIsLiked(action.is_liked);
+          setIsSubscribed(action.is_subscribed);
+        }
+
+        // 2. playlist 테이블에서 좋아요/구독 수 불러오기
+        const { data: playlistData } = await axiosInstance.get(`/playlist`, {
+          params: {
+            id: `eq.${playlistId}`,
+            select: "like_count,subscribe_count",
+          },
+        });
+
+        if (playlistData && playlistData.length > 0) {
+          setLikes(playlistData[0].like_count);
+          setSubscriptions(playlistData[0].subscribe_count);
+        }
+      } catch (error) {
+        console.error("액션 정보를 불러오는 중 오류 발생:", error);
+      }
+    };
+
+    fetchActions();
+  }, [playlistId, userId]);
+
+  // 좋아요/구독 통합 업데이트 함수
+  const updateAction = async ({
+    field,
+    value,
+  }: {
+    field: "is_liked" | "is_subscribed";
+    value: boolean;
+  }) => {
+    if (!userId) return;
+
+    try {
+      // 1. 기존 액션 row 있는지 확인
+      const { data: actionData } = await axiosInstance.get("/action", {
+        params: {
+          playlist_id: `eq.${playlistId}`,
+          user_id: `eq.${userId}`,
+          select: "*",
+        },
+      });
+      if (actionData.length === 0) {
+        // 2. 없으면 새로 생성 (상태 필드는 false로 초기화)
+        await axiosInstance.post("/action", {
+          user_id: userId,
+          playlist_id: playlistId,
+          [field]: value,
+          [field === "is_liked" ? "is_subscribed" : "is_liked"]: false,
+        });
+      } else {
+        // 3. 있으면 해당 필드만 업데이트
+        await axiosInstance.patch(
+          "/action",
+          { [field]: value },
+          {
+            params: {
+              playlist_id: `eq.${playlistId}`,
+              user_id: `eq.${userId}`,
+            },
+          },
+        );
+      }
+    } catch (error) {
+      console.error("action 업데이트 중 오류 발생:", error);
+      throw error;
+    }
   };
 
-  const handleSubscribe = () => {
-    setIsSubscribed((prev) => !prev);
-    setSubscriptions((prev) => (isSubscribed ? prev - 1 : prev + 1));
+  // 좋아요 버튼 클릭 핸들러
+  const handleLike = async () => {
+    if (!userId) return;
+    const newIsLiked = !isLiked;
+
+    // 클라이언트 UI 먼저 업데이트
+    setIsLiked(newIsLiked);
+    setLikes((prev) => (newIsLiked ? prev + 1 : prev - 1));
+
+    try {
+      // action 테이블 업데이트
+      await updateAction({ field: "is_liked", value: newIsLiked });
+
+      // playlist 테이블의 like_count 업데이트
+      await axiosInstance.patch(
+        "/playlist",
+        { like_count: newIsLiked ? likes + 1 : likes - 1 },
+        { params: { id: `eq.${playlistId}` } },
+      );
+    } catch (error) {
+      // 오류 발생 시 UI 롤백
+      setIsLiked((prev) => !prev);
+      setLikes((prev) => (newIsLiked ? prev - 1 : prev + 1));
+      console.error("action 업데이트 중 오류 발생:", error);
+    }
+  };
+
+  // 구독 버튼 클릭 핸들러
+  const handleSubscribe = async () => {
+    if (!userId) return;
+    const newIsSubscribed = !isSubscribed;
+
+    // 클라이언트 UI 먼저 업데이트
+    setIsSubscribed(newIsSubscribed);
+    setSubscriptions((prev) => (newIsSubscribed ? prev + 1 : prev - 1));
+
+    try {
+      // action 테이블 업데이트
+      await updateAction({ field: "is_subscribed", value: newIsSubscribed });
+
+      // playlist 테이블의 subscription_count 업데이트
+      await axiosInstance.patch(
+        "/playlist",
+        { subscribe_count: newIsSubscribed ? subscriptions + 1 : subscriptions - 1 },
+        { params: { id: `eq.${playlistId}` } },
+      );
+    } catch (error) {
+      // 오류 발생 시 UI 롤백
+      setIsSubscribed((prev) => !prev);
+      setSubscriptions((prev) => (newIsSubscribed ? prev - 1 : prev + 1));
+      console.error("action 업데이트 중 오류 발생:", error);
+    }
   };
 
   return (
@@ -30,22 +167,22 @@ const PlaylistActions = () => {
       <button
         onClick={handleSubscribe}
         role="button"
-        className="flex flex-row gap-[6px] items-center"
+        className="flex flex-row items-center gap-[6px]"
       >
         <BookmarkIcon
-          className={`w-[14px] h-[14px] ${isSubscribed ? "fill-white stroke-none" : "fill-none stroke-white"}`}
+          className={`h-[14px] w-[14px] ${isSubscribed ? "fill-white stroke-none" : "fill-none stroke-white"}`}
         />
         <span>{subscriptions}</span>
       </button>
-      <button onClick={handleLike} role="button" className="flex flex-row gap-[6px] items-center">
+      <button onClick={handleLike} role="button" className="flex flex-row items-center gap-[6px]">
         <HeartIcon
-          className={`w-[14px] h-[14px] ${isLiked ? "fill-white stroke-none" : "fill-none stroke-white"}`}
+          className={`h-[14px] w-[14px] ${isLiked ? "fill-white stroke-none" : "fill-none stroke-white"}`}
         />
         <span>{likes}</span>
       </button>
-      <div className="flex flex-row gap-[6px] items-center">
-        <CommentIcon className="w-[14px] h-[14px]" />
-        <span>{comments}</span>
+      <div className="flex flex-row items-center gap-[6px]">
+        <CommentIcon className="h-[14px] w-[14px]" />
+        <span>0</span> {/* 댓글 수 추후 구현 */}
       </div>
     </div>
   );

--- a/src/components/common/PlaylistAction.tsx
+++ b/src/components/common/PlaylistAction.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import useUserStore from "@/store/useUserStore";
 import axiosInstance from "@/services/axios/axiosInstance";
+import { usePlaylistDetail } from "@/hooks/usePlaylistDetail";
 
 import BookmarkIcon from "@/assets/icons/bookmark.svg?react";
 import HeartIcon from "@/assets/icons/heart.svg?react";
@@ -28,11 +29,6 @@ const PlaylistActions = ({ playlistId }: PlaylistActionsProps) => {
 
     setCommentCount(playlist?.data?.comment_count ?? 0);
   }, [playlist]);
-
-  const handleLike = () => {
-    setIsLiked((prev) => !prev);
-    setLikes((prev) => (isLiked ? prev - 1 : prev + 1));
-  // const [comments, setComments] = useState(0);
 
   // 유저와 플레이리스트에 대한 기존 액션 정보 불러오기
   useEffect(() => {

--- a/src/components/common/PlaylistCard.tsx
+++ b/src/components/common/PlaylistCard.tsx
@@ -85,7 +85,7 @@ const PlaylistCard = ({
             className="mb-[6px] mt-[12px]"
             onClick={(e) => e.stopPropagation()} // 이벤트 버블링 방지
           >
-            <PlaylistActions />
+            <PlaylistActions playlistId={id} />
           </div>
         </div>
       </div>

--- a/src/components/playlistDetail/Player.tsx
+++ b/src/components/playlistDetail/Player.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
-import { PlaylistDetailData } from "../../types/playlist";
-import { Video } from "../../types/video";
-import PlaylistActions from "../common/PlaylistAction";
-import { formatDate } from "../../utils/formatData";
+import { PlaylistDetailData } from "@/types/playlist";
+import { Video } from "@/types/video";
+import PlaylistActions from "@/components/common/PlaylistAction";
+import { formatDate } from "@/utils/formatData";
 import { useNavigate } from "react-router-dom";
 
 const MAX_DESCRIPTION_PREVIEW_LENGTH = 60;
@@ -104,7 +104,7 @@ const Player = ({ playlist, video }: { playlist: PlaylistDetailData; video: Vide
               </>
             )}
           </p>
-          <PlaylistActions />
+          <PlaylistActions playlistId={playlist.id} />
         </div>
       </section>
     </>

--- a/src/hooks/usePlaylistDetail.ts
+++ b/src/hooks/usePlaylistDetail.ts
@@ -7,7 +7,7 @@ const fetchPlaylist = async (playlistId: string): Promise<PlaylistDetailData> =>
   const { data: playlistData } = await axiosInstance.get(`/playlist`, {
     params: {
       id: `eq.${playlistId}`,
-      select: "*,user:creator_id(nickname,profile_image, id)",
+      select: "*,user:creator_id(nickname,profile_image,id)",
     },
   });
 


### PR DESCRIPTION
## ✨ Related Issues
- 이슈 넘버 #80 

## 📝 Task Details

- 로그인한 유저와 관련된 플레이리스트의 좋아요/구독 상태를 불러오는 로직 추가
- `playlistId`와 `userId`가 변경될 때마다 유저의 액션 상태와 플레이리스트의 좋아요/구독 수를 가져옴
- 좋아요/구독 상태를 업데이트하고, 해당 상태를 `action` 테이블에 반영
- 상태가 변경될 때, `playlist` 테이블의 카운트도 업데이트
- 오류 발생 시, UI 상태를 롤백

## 📂 References

https://github.com/user-attachments/assets/60ce6574-df05-477b-8d79-ed597619ef95

- user_id : 2238e111-0789-4ac3-8bdf-33047e3519a4
- playlist_id : 93568953-45e5-4a9a-81be-64e3003ac6dc

- 좋아요 한 상태
![image](https://github.com/user-attachments/assets/e6c398dc-23bc-443c-8602-89c0b662fc7e)
![image](https://github.com/user-attachments/assets/da4e4f69-3d5c-48f3-a401-48ddde96aaf0)
![image](https://github.com/user-attachments/assets/3343c3cd-57ba-47b0-b549-57821f5d0f68)

- 좋아요  하지 않은 상태
![image](https://github.com/user-attachments/assets/b587b7e7-5226-425d-965e-acae6965cf9e)
![image](https://github.com/user-attachments/assets/36de909c-1464-4f25-8ff9-31305c9ec233)
![image](https://github.com/user-attachments/assets/5261758c-bf9d-4e78-875e-2ecbb844d0e4)

## 💖 Review Requirements


