### PR TITLE
Feat: 댓글 카운트 표시 및 실시간 업데이트

### DIFF
--- a/src/components/common/PlaylistAction.tsx
+++ b/src/components/common/PlaylistAction.tsx
@@ -1,7 +1,9 @@
-import { useState } from "react";
-import BookmarkIcon from "../../assets/icons/bookmark.svg?react";
-import HeartIcon from "../../assets/icons/heart.svg?react";
-import CommentIcon from "../../assets/icons/comment.svg?react";
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { usePlaylistDetail } from "@/hooks/usePlaylistDetail";
+import BookmarkIcon from "@/assets/icons/bookmark.svg?react";
+import HeartIcon from "@/assets/icons/heart.svg?react";
+import CommentIcon from "@/assets/icons/comment.svg?react";
 
 // interface PlaylistActionsProps {
 //   playlistId: string; // 실제 API 연동 시 사용할 예정
@@ -13,7 +15,16 @@ const PlaylistActions = () => {
   const [isSubscribed, setIsSubscribed] = useState(false);
   const [likes, setLikes] = useState(0);
   const [subscriptions, setSubscriptions] = useState(0);
-  const [comments] = useState(0); // 댓글 수는 단순 표시용
+  const [commentCount, setCommentCount] = useState(0);
+
+  const { id } = useParams<{ id: string }>();
+  const playlist = usePlaylistDetail(id);
+
+  useEffect(() => {
+    if (!playlist) return;
+
+    setCommentCount(playlist?.data?.comment_count ?? 0);
+  }, [playlist]);
 
   const handleLike = () => {
     setIsLiked((prev) => !prev);
@@ -30,22 +41,22 @@ const PlaylistActions = () => {
       <button
         onClick={handleSubscribe}
         role="button"
-        className="flex flex-row gap-[6px] items-center"
+        className="flex flex-row items-center gap-[6px]"
       >
         <BookmarkIcon
-          className={`w-[14px] h-[14px] ${isSubscribed ? "fill-white stroke-none" : "fill-none stroke-white"}`}
+          className={`h-[14px] w-[14px] ${isSubscribed ? "fill-white stroke-none" : "fill-none stroke-white"}`}
         />
         <span>{subscriptions}</span>
       </button>
-      <button onClick={handleLike} role="button" className="flex flex-row gap-[6px] items-center">
+      <button onClick={handleLike} role="button" className="flex flex-row items-center gap-[6px]">
         <HeartIcon
-          className={`w-[14px] h-[14px] ${isLiked ? "fill-white stroke-none" : "fill-none stroke-white"}`}
+          className={`h-[14px] w-[14px] ${isLiked ? "fill-white stroke-none" : "fill-none stroke-white"}`}
         />
         <span>{likes}</span>
       </button>
-      <div className="flex flex-row gap-[6px] items-center">
-        <CommentIcon className="w-[14px] h-[14px]" />
-        <span>{comments}</span>
+      <div className="flex flex-row items-center gap-[6px]">
+        <CommentIcon className="h-[14px] w-[14px]" />
+        <span>{commentCount}</span>
       </div>
     </div>
   );

--- a/src/components/common/PlaylistAction.tsx
+++ b/src/components/common/PlaylistAction.tsx
@@ -1,15 +1,15 @@
 import { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+
 import { usePlaylistDetail } from "@/hooks/usePlaylistDetail";
 import BookmarkIcon from "@/assets/icons/bookmark.svg?react";
 import HeartIcon from "@/assets/icons/heart.svg?react";
 import CommentIcon from "@/assets/icons/comment.svg?react";
 
-// interface PlaylistActionsProps {
-//   playlistId: string; // 실제 API 연동 시 사용할 예정
-// }
+interface PlaylistActionsProps {
+  playlistId: string;
+}
 
-const PlaylistActions = () => {
+const PlaylistActions = ({ playlistId }: PlaylistActionsProps) => {
   // 기본 값으로 더미 데이터 사용 (API 연결 전까지)
   const [isLiked, setIsLiked] = useState(false);
   const [isSubscribed, setIsSubscribed] = useState(false);
@@ -17,8 +17,7 @@ const PlaylistActions = () => {
   const [subscriptions, setSubscriptions] = useState(0);
   const [commentCount, setCommentCount] = useState(0);
 
-  const { id } = useParams<{ id: string }>();
-  const playlist = usePlaylistDetail(id);
+  const playlist = usePlaylistDetail(playlistId);
 
   useEffect(() => {
     if (!playlist) return;

--- a/src/components/common/PlaylistCard.tsx
+++ b/src/components/common/PlaylistCard.tsx
@@ -85,7 +85,7 @@ const PlaylistCard = ({
             className="mb-[6px] mt-[12px]"
             onClick={(e) => e.stopPropagation()} // 이벤트 버블링 방지
           >
-            <PlaylistActions />
+            <PlaylistActions playlistId={id} />
           </div>
         </div>
       </div>

--- a/src/components/playlistDetail/Comments.tsx
+++ b/src/components/playlistDetail/Comments.tsx
@@ -60,6 +60,7 @@ const Comments = () => {
     onSuccess: () => {
       setContent("");
       queryClient.invalidateQueries({ queryKey: ["comments", playlistId] });
+      queryClient.invalidateQueries({ queryKey: ["playlist", playlistId] }); // 댓글 등록 시 comment_count update 되도록
     },
   });
 
@@ -78,7 +79,7 @@ const Comments = () => {
       {isCommentsLoading ? (
         <CommentSkeleton />
       ) : isCommentsError ? (
-        <p className="text-red-500 text-sub">댓글을 불러오는 데 실패했어요.</p>
+        <p className="text-sub text-red-500">댓글을 불러오는 데 실패했어요.</p>
       ) : (
         <>
           <span>댓글 {comments.length}</span>
@@ -99,7 +100,7 @@ const Comments = () => {
             )}
           </form>
           {isPostError && (
-            <p className="text-red-500 text-sub">댓글 등록에 실패했어요. 다시 시도해 주세요.</p>
+            <p className="text-sub text-red-500">댓글 등록에 실패했어요. 다시 시도해 주세요.</p>
           )}
           <ul className="flex flex-col gap-2">
             {comments.map((item) => (

--- a/src/components/playlistDetail/Player.tsx
+++ b/src/components/playlistDetail/Player.tsx
@@ -104,7 +104,7 @@ const Player = ({ playlist, video }: { playlist: PlaylistDetailData; video: Vide
               </>
             )}
           </p>
-          <PlaylistActions />
+          <PlaylistActions playlistId={playlist.id} />
         </div>
       </section>
     </>


### PR DESCRIPTION
## ✨ Related Issues
- 이슈 넘버 #101

## 📝 Task Details

``` sql
create or replace function update_comment_count()
returns trigger as $$
begin
  update playlist
  set comment_count = (
    select count(*) from comment where comment.playlist_id = NEW.playlist_id
  )
  where id = NEW.playlist_id;

  return null;
end;
$$ language plpgsql;
```
- Trigger Function 생성

``` sql
-- 댓글 추가 시
create trigger update_comment_count_after_insert
after insert on comment
for each row
execute function update_comment_count();

-- 댓글 삭제 시
create trigger update_comment_count_after_delete
after delete on comment
for each row
execute function update_comment_count();

```
-  INSERT/DELETE 시 작동하는 Trigger 연결 

위 두가지를 supabase에 등록하여 playlist db 내 `comment_count` 필드가 댓글 등록 시 자동 업데이트 되도록 구현하였습니다.
playlist id를 props로 전달 받아 `usePlaylistDetail` 훅을 통해 playlist를 조회하여 `comment_count`를 UI에 표시합니다.
추가로, `queryClient.invalidateQueries({ queryKey: ["playlist", playlistId] });` 를 통해 댓글 작성 성공 후, 강제 업데이트하여 댓글 카운트 또한 실시간으로 업데이트되도록 하였습니다.

## 📂 References

- 스크린샷이나 레퍼런스를 넣어주세요!

## 💖 Review Requirements

- 리뷰 요구사항을 적어주세요!
