### PR TITLE
Fix: 헤더 제거 검색기능 수정

### DIFF
--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -45,6 +45,9 @@ const Header = ({ onSearch }: HeaderProps) => {
   useEffect(() => {
     setSearchQuery("");
     setIsSearchOpen(false);
+    if (onSearch) {
+      onSearch("");
+    }
   }, [location.pathname]);
 
   // 플레이리스트 상세 제목 fetch
@@ -194,6 +197,9 @@ const Header = ({ onSearch }: HeaderProps) => {
   // 검색창 열기 및 포커스
   const handleSearchOpen = () => {
     setIsSearchOpen(true);
+    setTimeout(() => {
+      searchInputRef.current?.focus();
+    }, 0);
   };
 
   return (

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -2,16 +2,18 @@ import { Outlet, useLocation } from "react-router-dom";
 
 import Header from "./Header";
 import NavBar from "./NavBar";
+import useSearchStore from "@/store/useSearchStore";
 
 const Layout = () => {
   const location = useLocation();
+  const setSearchKeyword = useSearchStore((state) => state.setSearchKeyword);
 
   const hideAll = location.pathname === "/login";
   const hideNavOnly = ["/signup", "/user/edit", "/playlist/create"].includes(location.pathname);
 
   return (
     <div className="flex min-h-screen flex-col">
-      {!hideAll && <Header />}
+      {!hideAll && <Header onSearch={setSearchKeyword} />}
       <div
         className="scrollbar-hide overflow-y-auto pt-[60px]"
         style={{ height: "calc(100vh - 60px)" }}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,14 +5,12 @@ import { useEffect, useState } from "react";
 import PlaylistCard from "@/components/common/PlaylistCard";
 import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 import { usePlaylists } from "@/hooks/usePlaylists";
-import Header from "@/layout/Header";
+import useSearchStore from "@/store/useSearchStore";
 import useUserStore from "@/store/useUserStore";
 
 const Home = () => {
-  // const navigate = useNavigate();
-  const [searchKeyword, setSearchKeyword] = useState("");
+  const searchKeyword = useSearchStore((state) => state.searchKeyword);
   const userId = useUserStore.getState().user?.id;
-
 
   const { playlists, isLoading, hasMore, fetchNextPage, isFetchingNextPage } = usePlaylists({
     order: "subscribe_count.desc,updated_at.desc",
@@ -49,7 +47,6 @@ const Home = () => {
 
   return (
     <>
-      <Header onSearch={setSearchKeyword} />
       <div className="mb-[16px] ml-[19px] mt-[10px]">
         <h1 className="text-body1-bold">추천 플레이리스트</h1>
       </div>

--- a/src/pages/Subscriptions.tsx
+++ b/src/pages/Subscriptions.tsx
@@ -5,12 +5,11 @@ import { useEffect, useState } from "react";
 import PlaylistCard from "@/components/common/PlaylistCard";
 import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 import { usePlaylists } from "@/hooks/usePlaylists";
-import Header from "@/layout/Header";
-// import { usePlaylistSearch } from "@/hooks/usePlaylistSearch";
+import useSearchStore from "@/store/useSearchStore";
 import useUserStore from "@/store/useUserStore";
 
 const Subscriptions = () => {
-  const [searchKeyword, setSearchKeyword] = useState("");
+  const searchKeyword = useSearchStore((state) => state.searchKeyword);
   const userId = useUserStore.getState().user?.id;
   const [isLoadingMore, setIsLoadingMore] = useState(false);
 
@@ -46,7 +45,6 @@ const Subscriptions = () => {
 
   return (
     <>
-      <Header onSearch={setSearchKeyword} />
       <div className="mb-[16px] ml-[19px] mt-[10px]">
         <h1 className="text-body1-bold">구독 플레이리스트</h1>
       </div>

--- a/src/store/useSearchStore.ts
+++ b/src/store/useSearchStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface SearchState {
+  searchKeyword: string;
+  setSearchKeyword: (keyword: string) => void;
+}
+
+const useSearchStore = create<SearchState>((set) => ({
+  searchKeyword: "",
+  setSearchKeyword: (keyword) => set({ searchKeyword: keyword }),
+}));
+
+export default useSearchStore;


### PR DESCRIPTION
## ✨ Related Issues

- 이슈 넘버 #[issue_number]

## 📝 Task Details

- 헤더 제거
- 검색키워드와 설정함수 전역으로로 관리
- layout과 header에서 검색 관리, 페이지에서는 전역 상태 가져와서 사용
- 초기화 오류 수정
## 📂 References

https://github.com/user-attachments/assets/ead983d4-c88e-4741-8b12-78bcd32cd60a

---
페이지 이동시 검색어 초기화

https://github.com/user-attachments/assets/292f5160-b864-482f-ac56-24e06af45368



## 💖 Review Requirements

기존에 수정하면서 페이지 이동시 검색어 초기화 되는 부분이 사라진 것 같아요 우선 기능 확인해주시고..! 초기화하는 부분 추가로 pr올릴게요!

---
초기화 수정했습니다!
