### PR TITLE
Refactor: 검색 로직 수정

### DIFF
--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -1,52 +1,79 @@
-import { RefObject } from "react";
+import { RefObject, useEffect, useRef, useState } from "react";
 
 import { Input } from "./Input";
 import Cross from "@/assets/icons/cross.svg?react";
+import useSearchStore from "@/store/useSearchStore";
+import { useLocation } from "react-router-dom";
 
 interface SearchBarProps {
-  searchQuery: string;
   searchInputRef: RefObject<HTMLInputElement | null>;
-  onSearchQueryChange: (query: string) => void;
-  onSearch: (query: string) => void;
   onClose: () => void;
 }
 
-const SearchBar = ({
-  searchQuery,
-  searchInputRef,
-  onSearchQueryChange,
-  onSearch,
-  onClose,
-}: SearchBarProps) => {
-  // Enter 키 입력 시 검색 실행
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+const SearchBar = ({ searchInputRef, onClose }: SearchBarProps) => {
+  const location = useLocation();
+
+  const searchKeyword = useSearchStore((state) => state.searchKeyword);
+  const setSearchKeyword = useSearchStore((state) => state.setSearchKeyword);
+
+  const [searchQuery, setSearchQuery] = useState("");
+
+  // zustand 상태로 로컬 상태 초기화 (한 번만)
+  useEffect(() => {
+    setSearchQuery(searchKeyword);
+  }, [searchKeyword]);
+
+  // 검색창이 마운트되면 자동으로 포커스
+  useEffect(() => {
+    if (searchInputRef.current) {
+      searchInputRef.current.focus();
+    }
+  }, [searchInputRef]);
+
+  // 이전 경로를 저장
+  const prevPathRef = useRef(location.pathname);
+
+  // 페이지 이동 감지
+  useEffect(() => {
+    // 경로가 변경되었을 때
+    if (prevPathRef.current !== location.pathname) {
+      handleReset();
+      // 현재 경로 업데이트
+      prevPathRef.current = location.pathname;
+    }
+  }, [location.pathname]);
+
+  const handleSearch = (e: React.KeyboardEvent) => {
     if (e.key === "Enter") {
-      onSearch(searchQuery);
+      e.preventDefault();
+      if (searchQuery !== searchKeyword) {
+        setSearchKeyword(searchQuery);
+      }
     }
   };
 
-  // 닫기 버튼 클릭 시 검색어 초기화 및 검색창 닫기
-  const handleClose = () => {
-    onSearchQueryChange(""); // 검색어 초기화
-    onSearch(""); // 검색 결과 초기화
-    onClose(); // 검색창 닫기
+  // 검색어 초기화 및 검색창 닫기
+  const handleReset = () => {
+    setSearchQuery("");
+    setSearchKeyword("");
+    onClose();
   };
 
   return (
-    <div className="flex w-full items-center gap-3">
+    <form className="flex w-full items-center gap-3">
       <Input
         ref={searchInputRef}
         type="round"
         value={searchQuery}
-        onChange={(e) => onSearchQueryChange(e.target.value)}
-        onKeyDown={handleKeyDown}
+        onChange={(e) => setSearchQuery(e.target.value)}
+        onKeyDown={handleSearch}
         placeholder="검색어를 입력해주세요"
         className="flex-1"
       />
-      <button onClick={handleClose}>
+      <button type="button" onClick={handleReset}>
         <Cross />
       </button>
-    </div>
+    </form>
   );
 };
 

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -11,19 +11,14 @@ import axiosInstance from "@/services/axios/axiosInstance";
 import supabase from "@/services/supabase/supabaseClient";
 import useUserStore from "@/store/useUserStore";
 import { showToast } from "@/utils/toast";
-type HeaderProps = {
-  onSearch?: (query: string) => void;
-  nickname?: string;
-};
 
-const Header = ({ onSearch }: HeaderProps) => {
+const Header = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const [nickname, setNickname] = useState<string | null>(null);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [playlistTitle, setPlaylistTitle] = useState<string | null>(null);
   const [, setIsLoading] = useState(true);
-  const [searchQuery, setSearchQuery] = useState("");
   const [isOwner, setIsOwner] = useState(false);
 
   const searchInputRef: RefObject<HTMLInputElement | null> = useRef<HTMLInputElement>(null);
@@ -40,15 +35,6 @@ const Header = ({ onSearch }: HeaderProps) => {
     if (playlist.data?.creator_id === user.id) setIsOwner(true);
     else setIsOwner(false);
   }, [location, playlist.data?.creator_id, user]);
-
-  // 페이지 이동 시 검색 상태 초기화
-  useEffect(() => {
-    setSearchQuery("");
-    setIsSearchOpen(false);
-    if (onSearch) {
-      onSearch("");
-    }
-  }, [location.pathname]);
 
   // 플레이리스트 상세 제목 fetch
   useEffect(() => {
@@ -95,12 +81,6 @@ const Header = ({ onSearch }: HeaderProps) => {
 
     fetchNickname();
   }, [userId]);
-
-  useEffect(() => {
-    if (isSearchOpen) {
-      searchInputRef.current?.focus();
-    }
-  }, [isSearchOpen]);
 
   if (hiddenPaths.includes(location.pathname)) {
     return null;
@@ -194,14 +174,6 @@ const Header = ({ onSearch }: HeaderProps) => {
         ? playlistMenu
         : [];
 
-  // 검색창 열기 및 포커스
-  const handleSearchOpen = () => {
-    setIsSearchOpen(true);
-    setTimeout(() => {
-      searchInputRef.current?.focus();
-    }, 0);
-  };
-
   return (
     <header className="fixed top-0 z-10 flex h-[60px] w-full max-w-[430px] items-center bg-background-main px-4">
       {/* 왼쪽 영역 */}
@@ -228,19 +200,7 @@ const Header = ({ onSearch }: HeaderProps) => {
 
       {/* 검색창 */}
       {isSearchOpen && (
-        <SearchBar
-          searchQuery={searchQuery}
-          searchInputRef={searchInputRef}
-          onSearchQueryChange={setSearchQuery}
-          onSearch={onSearch || (() => {})}
-          onClose={() => {
-            setSearchQuery("");
-            setIsSearchOpen(false);
-            if (onSearch) {
-              onSearch("");
-            }
-          }}
-        />
+        <SearchBar searchInputRef={searchInputRef} onClose={() => setIsSearchOpen(false)} />
       )}
 
       {/* 오른쪽 영역 */}
@@ -248,7 +208,7 @@ const Header = ({ onSearch }: HeaderProps) => {
         {location.pathname === "/" || location.pathname === "/subscriptions" ? (
           <>
             {!isSearchOpen && (
-              <button onClick={handleSearchOpen}>
+              <button onClick={() => setIsSearchOpen(!isSearchOpen)}>
                 <Search />
               </button>
             )}

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -2,18 +2,16 @@ import { Outlet, useLocation } from "react-router-dom";
 
 import Header from "./Header";
 import NavBar from "./NavBar";
-import useSearchStore from "@/store/useSearchStore";
 
 const Layout = () => {
   const location = useLocation();
-  const setSearchKeyword = useSearchStore((state) => state.setSearchKeyword);
 
   const hideAll = location.pathname === "/login";
   const hideNavOnly = ["/signup", "/user/edit", "/playlist/create"].includes(location.pathname);
 
   return (
     <div className="flex min-h-screen flex-col">
-      {!hideAll && <Header onSearch={setSearchKeyword} />}
+      {!hideAll && <Header />}
       <div
         className="scrollbar-hide overflow-y-auto pt-[60px]"
         style={{ height: "calc(100vh - 60px)" }}


### PR DESCRIPTION
## ✨ Related Issues

- 이슈 넘버 #[issue_number]

## 📝 Task Details

- props로 컴포넌트 간 상태 전달을 줄이고 전역 상태를 활용할 수 있도록 했습니다.
- `SearchBar` 컴포넌트에서 사용자 입력 값을 위한 로컬 상태인 `searchQuery`로 관리합니다.
- 검색 창 open 시 Input focus, 페이지 이동 시 초기화 로직 등 `SearchBar` 컴포넌트 내에서 한 번에 관리할 수 있도록 했습니다. 
- `location.pathname`이 바뀔 때마다 무조건 초기화(`handleReset()`)를 호출하면, 컴포넌트가 처음 마운트될 때도 호출돼버려서 검색창이 열리면 바로 닫히게 됩니다.
그래서 `useRef`를 활용해 이전 경로를 저장하고, 현재 경로와 비교해서 진짜로 경로가 바뀌었을 때만 초기화 로직을 실행합니다.
- 사용자가 Enter를 누를 경우, 이전 검색어와 현재 검색 쿼리와 다를 경우만 리스트를 업데이트하여 불필요한 렌더링을 방지합니다.

## 📂 References

- 스크린샷이나 레퍼런스를 넣어주세요!

## 💖 Review Requirements

- 리뷰 요구사항을 적어주세요!
