### PR TITLE
Feat: 구독 수 실시간 동기화

### DIFF
--- a/src/components/common/PlaylistAction.tsx
+++ b/src/components/common/PlaylistAction.tsx
@@ -6,6 +6,7 @@ import HeartIcon from "@/assets/icons/heart.svg?react";
 import { usePlaylistDetail } from "@/hooks/usePlaylistDetail";
 import axiosInstance from "@/services/axios/axiosInstance";
 import useUserStore from "@/store/useUserStore";
+import { useQueryClient } from "@tanstack/react-query";
 
 interface PlaylistActionsProps {
   playlistId: string;
@@ -23,6 +24,8 @@ const PlaylistActions = ({ playlistId }: PlaylistActionsProps) => {
   const [commentCount, setCommentCount] = useState(0);
 
   const playlist = usePlaylistDetail(playlistId);
+
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     if (!playlist) return;
@@ -163,6 +166,10 @@ const PlaylistActions = ({ playlistId }: PlaylistActionsProps) => {
         { subscribe_count: newIsSubscribed ? subscriptions + 1 : subscriptions - 1 },
         { params: { id: `eq.${playlistId}` } },
       );
+
+      if (userId) {
+        queryClient.invalidateQueries({ queryKey: ["userInfo", userId] });
+      }
     } catch (error) {
       // 오류 발생 시 UI 롤백
       setIsSubscribed((prev) => !prev);


### PR DESCRIPTION
## ✨ Related Issues

- 이슈 넘버 #[issue_number]

## 📝 Task Details

- 마이페이지에 표시되는 구독 수가 실제 유저가 만든 플레이리스트 구독 수의 총합이 되도록 supabase에서 세팅했습니다!
- 이후 playlist 테이블의 subscribe_count가 바뀔 때마다 user 테이블을 자동 업데이트하는 트리거를 만들어 두었습니다.
  * 함수
  ``` javascript
  BEGIN
    UPDATE "user"
    SET subscribe_count = (
      SELECT COALESCE(SUM(subscribe_count), 0)
      FROM playlist
      WHERE creator_id = NEW.creator_id
    )
    WHERE id = NEW.creator_id;
  
    RETURN NEW;
  END;
  ```
  
  * 트리거
  ``` javascript
  CREATE TRIGGER playlist_subscribe_count_change
  AFTER INSERT OR UPDATE OR DELETE ON playlist
  FOR EACH ROW
  EXECUTE FUNCTION update_user_subscribe_count();
  ```

- UI에서도 구독을 누를 경우, 위를 통해 user 테이블이 변하면 refetch하여 최신 데이터가 반영되도록 로직 추가하였습니다!
 `queryClient.invalidateQueries({ queryKey: ["userInfo", userId] });`

## 📂 References

- 스크린샷이나 레퍼런스를 넣어주세요!

## 💖 Review Requirements

- 리뷰 요구사항을 적어주세요!
